### PR TITLE
Enable Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+   # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION


### What changes were proposed in this pull request?
Enable dependabot to get security updates and if needed version updates on dependencies 

### Why are the changes needed?

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

Having knowledge about vulnerabilities of the dependencies helps the project owners decide on their dependencies security posture to make decisions.

If the project decides to get updates only on security updates and not on any version updates then setting these options would not open any PR 's `open-pull-requests-limit: 0`


### Does this PR introduce _any_ user-facing change?
NO
This option has to be enabled in the security section of the project.
https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories
### How was this patch tested?
N/A
